### PR TITLE
Stabilize test setup and configure Renovate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,13 +49,6 @@
 			<artifactId>log4j-api</artifactId>
 			<version>2.17.2</version>
 		</dependency>
-		<!-- https://mvnrepository.com/artifact/org.testng/testng -->
-		<dependency>
-			<groupId>org.testng</groupId>
-			<artifactId>testng</artifactId>
-			<version>7.8.0</version>
-			<scope>test</scope>
-		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
 		<dependency>
 			<groupId>org.mockito</groupId>
@@ -70,11 +63,11 @@
 			<version>2.2</version>
 			<scope>test</scope>
 		</dependency>
-		<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
+		<!-- https://mvnrepository.com/artifact/junit/junit -->
 		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.10.1</version>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -132,6 +125,12 @@
 			<groupId>com.googlecode.json-simple</groupId>
 			<artifactId>json-simple</artifactId>
 			<version>1.1.1</version>
+			<exclusions>
+				<exclusion>
+					<groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "baseBranchPatterns": [
+    "develop"
+  ],
+  "dependencyDashboard": true,
+  "labels": [
+    "dependencies"
+  ],
+  "prConcurrentLimit": 4,
+  "packageRules": [
+    {
+      "description": "Keep HAPI FHIR updates separate because validator behavior can change.",
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "/^ca\\.uhn\\.hapi\\.fhir:/"
+      ],
+      "groupName": "HAPI FHIR"
+    },
+    {
+      "description": "Group low-risk Maven test dependencies.",
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "junit:junit",
+        "org.mockito:mockito-core",
+        "org.hamcrest:hamcrest"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "Maven test dependencies"
+    },
+    {
+      "description": "Group low-risk Maven runtime dependency patch and minor updates.",
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "org.apache.commons:commons-csv",
+        "info.picocli:picocli",
+        "org.apache.poi:poi",
+        "org.apache.poi:poi-ooxml",
+        "org.apache.logging.log4j:log4j-api",
+        "org.apache.logging.log4j:log4j-core",
+        "org.apache.logging.log4j:log4j-slf4j-impl",
+        "org.apache.maven.plugins:maven-shade-plugin"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "Maven runtime and build dependencies"
+    },
+    {
+      "description": "Group GitHub Actions patch and minor updates.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "GitHub Actions"
+    },
+    {
+      "description": "Keep major updates separate for review.",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "dependencyDashboardApproval": true
+    }
+  ]
+}

--- a/src/test/java/de/uni_leipzig/imise/utils/AlphabeticalTest.java
+++ b/src/test/java/de/uni_leipzig/imise/utils/AlphabeticalTest.java
@@ -3,18 +3,18 @@ package de.uni_leipzig.imise.utils;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.collection.ArrayMatching.arrayContaining;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
-import org.testng.annotations.Test;
-import org.testng.collections.Lists;
+import org.junit.Test;
 
 public class AlphabeticalTest {
 
@@ -25,9 +25,13 @@ public class AlphabeticalTest {
         assertEquals(localizedComparator1, localizedComparator2);
         Locale defaultLocale = Locale.getDefault();
         Locale newLocale = Locale.GERMAN.equals(defaultLocale) ? Locale.ENGLISH : Locale.GERMAN;
-        Locale.setDefault(newLocale);
-        localizedComparator2 = Alphabetical.getLocalizedComparator();
-        assertNotEquals(localizedComparator1, localizedComparator2);
+        try {
+            Locale.setDefault(newLocale);
+            localizedComparator2 = Alphabetical.getLocalizedComparator();
+            assertNotEquals(localizedComparator1, localizedComparator2);
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
     }
 
     @Test
@@ -41,20 +45,20 @@ public class AlphabeticalTest {
         when(mock2.toString()).thenReturn("1.1 a.");
         when(mock3.toString()).thenReturn("1.2");
 
-        mocks = Lists.newArrayList(mock1, mock2);
+        mocks = new ArrayList<>(Arrays.asList(mock1, mock2));
         Alphabetical.insert(mocks, mock3);
         assertThat(mocks, contains(mock1, mock2, mock3));
 
-        mocks = Lists.newArrayList(mock2, mock3);
+        mocks = new ArrayList<>(Arrays.asList(mock2, mock3));
         Alphabetical.insert(mocks, mock1);
         assertThat(mocks, contains(mock1, mock2, mock3));
 
-        mocks = Lists.newArrayList(mock1, mock3);
+        mocks = new ArrayList<>(Arrays.asList(mock1, mock3));
         Alphabetical.insert(mocks, mock2);
         assertThat(mocks, contains(mock1, mock2, mock3));
 
         Object mock21 = mock2;
-        mocks = Lists.newArrayList(mock1, mock2, mock3);
+        mocks = new ArrayList<>(Arrays.asList(mock1, mock2, mock3));
         Alphabetical.insert(mocks, mock21);
         assertThat(mocks, contains(mock1, mock2, mock21, mock3));
 
@@ -141,9 +145,9 @@ public class AlphabeticalTest {
         when(mock4.toString()).thenReturn("1.1 a.");
 
         //sorted list
-        List<Object> mocksList = Lists.newArrayList(mock1, mock2, mock3);
+        List<Object> mocksList = new ArrayList<>(Arrays.asList(mock1, mock2, mock3));
         int index = Alphabetical.binarySearch(mocksList, mock4);
-        assertEquals(index, 1);
+        assertEquals(1, index);
     }
 
 }

--- a/src/test/java/de/uni_leipzig/life/csv2fhir/converter/ConditionConverterTest.java
+++ b/src/test/java/de/uni_leipzig/life/csv2fhir/converter/ConditionConverterTest.java
@@ -1,95 +1,71 @@
 package de.uni_leipzig.life.csv2fhir.converter;
 
 import static de.uni_leipzig.life.csv2fhir.TableIdentifier.Fall;
-import static de.uni_leipzig.life.csv2fhir.converter.ConditionConverter.Diagnosis_Columns.Dokumentationsdatum;
-import static de.uni_leipzig.life.csv2fhir.converter.ConditionConverter.Diagnosis_Columns.ICD;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
+import java.io.StringReader;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.hl7.fhir.r4.model.CodeableConcept;
 import org.hl7.fhir.r4.model.Coding;
 import org.hl7.fhir.r4.model.Condition;
 import org.hl7.fhir.r4.model.Encounter;
 import org.hl7.fhir.r4.model.Resource;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.Assert;
+import org.junit.Test;
 
 import de.uni_leipzig.life.csv2fhir.ConverterOptions;
-import de.uni_leipzig.life.csv2fhir.ConverterOptions.BooleanOption;
 import de.uni_leipzig.life.csv2fhir.ConverterResult;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ConditionConverterTest {
 
     @Test
     public void convertTest() throws Exception {
-        CSVRecord recordMock = mock(CSVRecord.class);
-        doReturn("PID1").when(recordMock).get("Patient-ID");
-        ConverterResult resultMock = mock(ConverterResult.class);
-        ConverterOptions optionsMock = mock(ConverterOptions.class);
-        //doReturn(true).when(optionsMock).is(BooleanOption.SET_REFERENCE_FROM_CONDITION_TO_ENCOUNTER);
-        doReturn(true).when(optionsMock).is(Mockito.any(BooleanOption.class));
-        doReturn(optionsMock).when(resultMock).getConverterOptions();
+        ConverterResult result = new ConverterResult(new ConverterOptions(""));
 
-        doReturn("PID1").when(recordMock).get("Patient-ID");
-        //FHIRValidator validator = mock(FHIRValidator.class);
-        ConditionConverter diagnosisConverterUnderTest = new ConditionConverter(recordMock, null, resultMock, null, new ConverterOptions(""));
-
-        //doReturn(null).when(recordMock).get("ICD");
-        when(recordMock.get("ICD")).thenReturn(null);
-        Assertions.assertThrows(Exception.class, () -> {
-            diagnosisConverterUnderTest.convertInternal();
+        Assert.assertThrows(Exception.class, () -> {
+            newConditionConverter(null, result).convertInternal();
         });
 
-        when(recordMock.get("ICD")).thenReturn("");
-        Assertions.assertThrows(Exception.class, () -> {
-            diagnosisConverterUnderTest.convertInternal();
+        Assert.assertThrows(Exception.class, () -> {
+            newConditionConverter("", result).convertInternal();
         });
 
-        when(recordMock.get("ICD")).thenReturn(" \t ");
-        Assertions.assertThrows(Exception.class, () -> {
-            diagnosisConverterUnderTest.convertInternal();
+        Assert.assertThrows(Exception.class, () -> {
+            newConditionConverter(" \t ", result).convertInternal();
         });
 
-        testConvert(diagnosisConverterUnderTest, recordMock, resultMock, "A12.34", "A12.34");
-        testConvert(diagnosisConverterUnderTest, recordMock, resultMock, "A12.3", "A12.3");
-        testConvert(diagnosisConverterUnderTest, recordMock, resultMock, "A12.", "A12");
-        testConvert(diagnosisConverterUnderTest, recordMock, resultMock, "A12", "A12");
-        testConvert(diagnosisConverterUnderTest, recordMock, resultMock, "A12.34A12.34", "A12.34");
-        testConvert(diagnosisConverterUnderTest, recordMock, resultMock, "A12.34A", "A12.34");
-        testConvert(diagnosisConverterUnderTest, recordMock, resultMock, "A1");
+        testConvert("A12.34", "A12.34");
+        testConvert("A12.3", "A12.3");
+        testConvert("A12.", "A12");
+        testConvert("A12", "A12");
+        testConvert("A12.34A12.34", "A12.34");
+        testConvert("A12.34A", "A12.34");
+        testConvert("A1");
 
-        testConvert(diagnosisConverterUnderTest, recordMock, resultMock, "A12.34A12.3", "A12.34", "A12.3");
-        testConvert(diagnosisConverterUnderTest, recordMock, resultMock, "A12.34A12.", "A12.34", "A12");
-        testConvert(diagnosisConverterUnderTest, recordMock, resultMock, "A12.34A12.", "A12.34", "A12");
+        testConvert("A12.34A12.3", "A12.34", "A12.3");
+        testConvert("A12.34A12.", "A12.34", "A12");
+        testConvert("A12.34A12.", "A12.34", "A12");
 
-        testConvert(diagnosisConverterUnderTest, recordMock, resultMock, "F02.3*+G20.10", "F02.3", "G20.10");
+        testConvert("F02.3*+G20.10", "F02.3", "G20.10");
 
     }
 
     /**
-     * @param diagnosisConverter
-     * @param recordMock
-     * @param resultMock
      * @param codeInput
      * @param resultCodes
      */
-    private static void testConvert(ConditionConverter diagnosisConverter, CSVRecord recordMock, ConverterResult resultMock, String codeInput, String... expectedResultCodes) throws Exception {
-        String recordedDate = "02.10.2020 00:00";
-        doReturn(recordedDate).when(recordMock).get(Dokumentationsdatum.toString());
-
-        when(recordMock.get(ICD.toString())).thenReturn(codeInput);
-        when(resultMock.get(Fall, Encounter.class, diagnosisConverter.getEncounterId())).thenReturn(new Encounter());
+    private static void testConvert(String codeInput, String... expectedResultCodes) throws Exception {
+        ConverterResult result = new ConverterResult(new ConverterOptions(""));
+        Encounter encounter = new Encounter();
+        encounter.setId("PID1-E-1");
+        result.add(Fall, encounter);
+        ConditionConverter diagnosisConverter = newConditionConverter(codeInput, result);
         List<Resource> convertedResources = diagnosisConverter.convertInternal();
         int convertedResourcesCount = convertedResources == null ? 0 : convertedResources.size();
         assertEquals(convertedResourcesCount, expectedResultCodes.length);
@@ -106,5 +82,34 @@ public class ConditionConverterTest {
         }
         //check whether always different IDs are generated
         assertEquals(conditionIDs.size(), convertedResourcesCount);
+    }
+
+    /**
+     * @param icdCode
+     * @param result
+     * @return
+     * @throws Exception
+     */
+    private static ConditionConverter newConditionConverter(String icdCode, ConverterResult result) throws Exception {
+        CSVRecord record = createRecord(icdCode);
+        return new ConditionConverter(record, null, result, null, new ConverterOptions(""));
+    }
+
+    /**
+     * @param icdCode
+     * @return
+     * @throws Exception
+     */
+    private static CSVRecord createRecord(String icdCode) throws Exception {
+        String value = icdCode == null ? "" : icdCode;
+        String csv = "Patient-ID,Fall-Nr,Bezeichner,ICD,Dokumentationsdatum,Typ\n"
+                + "PID1,1,," + value + ",02.10.2020 00:00,\n";
+        CSVFormat csvFormat = CSVFormat.DEFAULT.builder()
+                .setNullString("")
+                .setHeader()
+                .setSkipHeaderRecord(true)
+                .build();
+        CSVParser parser = csvFormat.parse(new StringReader(csv));
+        return parser.getRecords().get(0);
     }
 }

--- a/src/test/java/de/uni_leipzig/life/csv2fhir/utils/DecimalUtilTest.java
+++ b/src/test/java/de/uni_leipzig/life/csv2fhir/utils/DecimalUtilTest.java
@@ -1,12 +1,12 @@
 package de.uni_leipzig.life.csv2fhir.utils;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.math.BigDecimal;
 
-import org.junit.jupiter.api.Assertions;
-import org.testng.annotations.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class DecimalUtilTest {
 
@@ -30,7 +30,7 @@ public class DecimalUtilTest {
         assertEquals(dec, new BigDecimal("6.2"));
         dec = DecimalUtil.parseDecimal("6,2");
         assertEquals(dec, new BigDecimal("6.2"));
-        Assertions.assertThrows(Exception.class, () -> {
+        Assert.assertThrows(Exception.class, () -> {
             DecimalUtil.parseDecimal("aaa");
         });
 

--- a/src/test/java/heuschkel/life/de/MainTest.java
+++ b/src/test/java/heuschkel/life/de/MainTest.java
@@ -1,33 +1,18 @@
 package heuschkel.life.de;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
 
 /**
  * Unit test for simple App.
  */
-public class MainTest extends TestCase {
-
-    /**
-     * Create the test case
-     *
-     * @param testName name of the test case
-     */
-    public MainTest(String testName) {
-        super(testName);
-    }
-
-    /**
-     * @return the suite of tests being tested
-     */
-    public static Test suite() {
-        return new TestSuite(MainTest.class);
-    }
+public class MainTest {
 
     /**
      * Rigourous Test :-)
      */
+    @Test
     public void testApp() {
         assertTrue(true);
     }

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,1 @@
-mock-maker-inline
+mock-maker-subclass


### PR DESCRIPTION
## Summary

- consolidate Maven test setup on JUnit 4 and remove mixed TestNG/JUnit Jupiter usage
- avoid Mockito inline mocking for final CSVRecord by using real CSV parser records in tests
- add Renovate configuration targeting develop with grouped low-risk updates and dashboard approval for major updates

## Verification

- mvn test