### PR TITLE
Improve Docker workbook handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,212 @@
 # excel2fhir
 
-07/14/2023: Repo copied from https://github.com/fmeineke/csv2fhir
+`excel2fhir` converts structured Excel workbooks into synthetic FHIR R4 test data
+bundles. It is intended for creating coherent, referenced test data in the context of
+the German Medical Informatics Initiative (MII) Kerndatensatz.
 
-## Background / History
+The input is an Excel workbook with predefined sheets for patients, encounters,
+diagnoses, procedures, observations, medication, clinical documentation and conversion
+options. The generator splits the workbook into intermediate CSV files and then creates
+FHIR resources and bundles.
 
-The need for FHIR test data was and is urgent. In the POLAR_MI use case (2020-2022), medication elements were also required for the first time.
-Here, clinicians were asked to **invent** data sets. For this purpose, an Excel spreadsheet was prepared from which FHIR resources were ultimately generated.
-From the beginning, care was taken to create coherent, valid referenced bundles (i.e. including patient, encounter, etc.).
-The system was also continuously expanded to include new resource types (e.g. DocumentReference).
-The generated resources strive for MII KDS validity - but are only adjusted sporadically here.
+## Current Scope
 
-## Working method
+The converter currently supports the following logical data areas:
 
-An ExcelFile template is filled. The java based processor generates FHIR R4 resources.
+- Patient data (`Person`)
+- Encounter data (`Fall`)
+- Diagnoses / conditions (`Diagnose`)
+- Procedures (`Prozedur`)
+- Laboratory observations (`Laborbefund`)
+- Vital signs / clinical documentation (`Klinische Dokumentation`)
+- Medication data (`Medikation`)
+- Document references (`DocumentReference`)
+- Consent data (`Consent`, currently represented on the patient sheet)
+- Conversion options (`Konvertierungsoptionen`)
 
-## Authors 
-Early versions were developed by F. Meineke and AG A. Kiel developed.  Later versions, extensions and corrections were made by A. Strübing, with contribution F. Meineke et. al.
+The generated resources aim to be suitable for MII KDS-oriented test data scenarios.
+Profile conformance depends on the current converter implementation, bundled validation
+resources and the profile versions used by downstream systems.
 
+## Excel Templates
+
+The repository contains two workbooks:
+
+- `FHIR_Testdatengenerator_Vorlage.xlsx` - the default input template.
+- `FHIR_Testdatengenerator_Interpolar_Demo.xlsx` - a small demo workbook with coherent
+  example data.
+
+The sheet names and many comments in the workbook are German because the template is
+aligned with the German MII Kerndatensatz context.
+
+When running the application without input arguments, `FHIR_Testdatengenerator_Vorlage.xlsx`
+from the application directory is used as the default input file.
+
+## Requirements
+
+- Java 17
+- Maven 3.x
+
+## Quick Start
+
+Build and run the default template:
+
+```bash
+mvn -q compile exec:java \
+  -Dexec.mainClass=de.uni_leipzig.imise.Excel2FhirMain
+```
+
+Run the demo workbook explicitly:
+
+```bash
+mvn -q compile exec:java \
+  -Dexec.mainClass=de.uni_leipzig.imise.Excel2FhirMain \
+  -Dexec.args="-f FHIR_Testdatengenerator_Interpolar_Demo.xlsx"
+```
+
+Run with FHIR resource validation enabled:
+
+```bash
+mvn -q compile exec:java \
+  -Dexec.mainClass=de.uni_leipzig.imise.Excel2FhirMain \
+  -Dexec.args="-v -f FHIR_Testdatengenerator_Interpolar_Demo.xlsx"
+```
+
+Create the executable JAR:
+
+```bash
+mvn package
+java -jar target/excel2fhir.jar -f FHIR_Testdatengenerator_Interpolar_Demo.xlsx
+```
+
+## Output
+
+By default, output is written next to the input workbook:
+
+- `outputLocal/` contains intermediate CSV files extracted from the Excel workbook.
+- `outputGlobal/` contains the generated FHIR bundle files.
+
+The default result format is JSON. Additional output formats can be selected with
+`-r` / `--result-file-format`:
+
+- `JSON`
+- `XML`
+- `NDJSON`
+- `JSONGZIP`
+- `JSONBZ2`
+
+Example:
+
+```bash
+java -jar target/excel2fhir.jar \
+  -f FHIR_Testdatengenerator_Interpolar_Demo.xlsx \
+  -r JSON,NDJSON
+```
+
+## Command Line Options
+
+```text
+-f,   --input-file INPUT-File
+      Input Excel file. If specified, the input directory is ignored.
+
+-i,   --input-directory INPUT-DIRECTORY
+      Directory containing Excel files to convert.
+
+-o,   --output-directory OUTPUT-DIRECTORY
+      Directory for generated FHIR result files.
+
+-t,   --temp-directory TEMP-DIRECTORY
+      Directory for intermediate CSV files.
+
+-r,   --result-file-format RESULT-FILE-FORMAT
+      Comma-separated output formats: JSON, XML, NDJSON, JSONGZIP or JSONBZ2.
+
+-p,   --patients-count PATIENTS-COUNT
+      Maximum number of patients per output bundle.
+
+-v,   --validate-bundles / --no-validate-bundles
+      Validate generated FHIR resources and include only valid resources.
+
+-vll, --validation-log-level VALIDATION-LOG-LEVEL
+      Minimum validation log level. Supported values include ERROR, WARNING, IGNORED and VALID.
+```
+
+You can also use the built-in help:
+
+```bash
+java -jar target/excel2fhir.jar --help
+```
+
+## Validation
+
+There are two validation layers:
+
+1. Excel template validation checks the structure and consistency of the workbook before
+   conversion.
+2. FHIR resource validation can be enabled with `-v` / `--validate-bundles`.
+
+Strict Excel template validation is enabled by default. It can be configured via
+converter options if a test-data scenario intentionally needs more permissive behavior.
+
+When FHIR validation is enabled, invalid resources are not added to the generated bundle.
+Validation warnings may still be expected depending on the test-data use case and the
+profile versions used.
+
+## Converter Options
+
+Conversion behavior can be configured through the `Konvertierungsoptionen` sheet in the
+workbook. Default values are documented in:
+
+```text
+src/main/resources/Converter_Options.config
+```
+
+Examples include:
+
+- start counters for generated resource identifiers
+- whether circular references between encounters and diagnoses/procedures should be generated
+- whether missing encounter data should be filled from parent encounters
+- whether strict Excel template validation should be active
+
+## Docker
+
+A Docker setup is available for running the default template:
+
+```bash
+docker compose -f docker/docker-compose.yml up --build
+```
+
+The compose setup mounts `outputGlobal/` and `outputLocal/` from the repository root into
+the container.
+
+## Development
+
+Run the test suite:
+
+```bash
+mvn test
+```
+
+Build the project:
+
+```bash
+mvn package
+```
+
+The GitHub Actions workflow runs Maven tests, CodeQL analysis, Docker image build and
+Trivy vulnerability scanning.
+
+## Repository Layout
+
+```text
+FHIR_Testdatengenerator_Vorlage.xlsx          Default Excel template
+FHIR_Testdatengenerator_Interpolar_Demo.xlsx  Demo workbook
+src/main/java/                                Converter implementation
+src/main/resources/                           Mapping and converter option defaults
+docker/                                       Docker build and compose setup
+.github/workflows/                            CI workflow
+```
+
+## License
+
+See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -170,14 +170,51 @@ Examples include:
 
 ## Docker
 
-A Docker setup is available for running the default template:
+Docker can be used without a local Java or Maven installation. The compose setup mounts
+the repository root read-only as `/app/input` and writes generated files to the host
+directories `outputGlobal/` and `outputLocal/`.
+
+Run the bundled default template:
 
 ```bash
-docker compose -f docker/docker-compose.yml up --build
+docker compose -f docker/docker-compose.yml run --rm excel2fhir
 ```
 
-The compose setup mounts `outputGlobal/` and `outputLocal/` from the repository root into
-the container.
+Run the demo workbook from the repository:
+
+```bash
+docker compose -f docker/docker-compose.yml run --rm excel2fhir \
+  -f /app/input/FHIR_Testdatengenerator_Interpolar_Demo.xlsx
+```
+
+Run a self-edited workbook stored in the repository directory. Replace
+`my-workbook.xlsx` with the actual file name:
+
+```bash
+docker compose -f docker/docker-compose.yml run --rm excel2fhir \
+  -f /app/input/my-workbook.xlsx
+```
+
+Write one JSON bundle per patient:
+
+```bash
+docker compose -f docker/docker-compose.yml run --rm excel2fhir \
+  -f /app/input/FHIR_Testdatengenerator_Interpolar_Demo.xlsx \
+  -p 1
+```
+
+Additional CLI options can be passed after the service name. If no output or temp
+directory is provided, the Docker entrypoint defaults to `/app/outputGlobal` and
+`/app/outputLocal`, which are mounted to `outputGlobal/` and `outputLocal/` on the host.
+
+Example with FHIR validation and NDJSON output:
+
+```bash
+docker compose -f docker/docker-compose.yml run --rm excel2fhir \
+  -f /app/input/FHIR_Testdatengenerator_Interpolar_Demo.xlsx \
+  -v \
+  -r JSON,NDJSON
+```
 
 ## Development
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8.3-openjdk-17 AS MAVEN_TOOL_CHAIN
+FROM maven:3.8.3-openjdk-17 AS maven_tool_chain
 COPY pom.xml /tmp/
 COPY . /tmp/
 WORKDIR /tmp/
@@ -7,11 +7,12 @@ RUN mvn clean install
 
 FROM amazoncorretto:17-alpine
 
-COPY --from=MAVEN_TOOL_CHAIN /tmp/target/excel2fhir.jar /app/excel2fhir.jar
+COPY --from=maven_tool_chain /tmp/target/excel2fhir.jar /app/excel2fhir.jar
 COPY FHIR_Testdatengenerator_Vorlage.xlsx /app/
 COPY docker/docker-entrypoint.sh /app/
 
 WORKDIR /app
+RUN mkdir -p /app/outputGlobal /app/outputLocal && chmod +x /app/docker-entrypoint.sh
 USER 1001
 
-ENTRYPOINT  sh docker-entrypoint.sh
+ENTRYPOINT ["sh", "/app/docker-entrypoint.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,9 +1,9 @@
-version: '3.7'
 services:
   excel2fhir:
     build:
       context: ..
       dockerfile: docker/Dockerfile
     volumes:
+      - "../:/app/input:ro"
       - "../outputGlobal:/app/outputGlobal"
       - "../outputLocal:/app/outputLocal"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,6 +1,92 @@
-#!/bin/bash
+#!/bin/sh
+set -eu
 
-printf "Staring excel2fhir fhir with the following configurations:\n"
-printf "input file: FHIR_Testdatengenerator_Vorlage.xlsx\n\n"
+JAR_FILE="/app/excel2fhir.jar"
+DEFAULT_INPUT_FILE="/app/FHIR_Testdatengenerator_Vorlage.xlsx"
+DEFAULT_OUTPUT_DIRECTORY="/app/outputGlobal"
+DEFAULT_TEMP_DIRECTORY="/app/outputLocal"
 
-java -jar excel2fhir.jar
+has_input=false
+has_output_directory=false
+has_temp_directory=false
+show_help_or_version=false
+input_file=""
+input_directory=""
+next_argument_is_input_file=false
+next_argument_is_input_directory=false
+
+for argument in "$@"; do
+  if [ "$next_argument_is_input_file" = true ]; then
+    input_file="$argument"
+    next_argument_is_input_file=false
+    continue
+  fi
+  if [ "$next_argument_is_input_directory" = true ]; then
+    input_directory="$argument"
+    next_argument_is_input_directory=false
+    continue
+  fi
+
+  case "$argument" in
+    -f|--input-file)
+      has_input=true
+      next_argument_is_input_file=true
+      ;;
+    -f=*|--input-file=*)
+      has_input=true
+      input_file="${argument#*=}"
+      ;;
+    -i|--input-directory)
+      has_input=true
+      next_argument_is_input_directory=true
+      ;;
+    -i=*|--input-directory=*)
+      has_input=true
+      input_directory="${argument#*=}"
+      ;;
+    -o|-o=*|--output-directory|--output-directory=*)
+      has_output_directory=true
+      ;;
+    -t|-t=*|--temp-directory|--temp-directory=*)
+      has_temp_directory=true
+      ;;
+    -h|--help|-V|--version)
+      show_help_or_version=true
+      ;;
+  esac
+done
+
+if [ "$show_help_or_version" = true ]; then
+  exec java -jar "$JAR_FILE" "$@"
+fi
+
+if [ "$#" -eq 0 ]; then
+  set -- -f "$DEFAULT_INPUT_FILE"
+elif [ "$has_input" = false ]; then
+  set -- -f "$DEFAULT_INPUT_FILE" "$@"
+fi
+
+if [ "$has_output_directory" = false ]; then
+  set -- "$@" -o "$DEFAULT_OUTPUT_DIRECTORY"
+fi
+
+if [ "$has_temp_directory" = false ]; then
+  set -- "$@" -t "$DEFAULT_TEMP_DIRECTORY"
+fi
+
+if [ -n "$input_file" ] && [ ! -f "$input_file" ]; then
+  printf "Input file not found inside the container: %s\n" "$input_file" >&2
+  printf "Put the workbook in the repository directory and pass it as /app/input/<file-name>.xlsx.\n" >&2
+  exit 1
+fi
+
+if [ -n "$input_directory" ] && [ ! -d "$input_directory" ]; then
+  printf "Input directory not found inside the container: %s\n" "$input_directory" >&2
+  printf "Mount or choose a directory below /app/input.\n" >&2
+  exit 1
+fi
+
+printf "Starting excel2fhir with arguments:\n"
+printf "  %s\n" "$*"
+
+exec java -jar "$JAR_FILE" "$@"

--- a/src/main/java/de/uni_leipzig/life/csv2fhir/Csv2Fhir.java
+++ b/src/main/java/de/uni_leipzig/life/csv2fhir/Csv2Fhir.java
@@ -240,7 +240,7 @@ public class Csv2Fhir {
                     if (lastPID != null) {
                         String fileNameExtendsion = converterOptions.getPrefixWithSuffix();
                         if (pids.size() > patientsPerBundle) {
-                            fileNameExtendsion = firstPID == lastPID ? firstPID : firstPID + "-" + lastPID;
+                            fileNameExtendsion = firstPID.equals(lastPID) ? firstPID : firstPID + "-" + lastPID;
                         }
                         writeOutputFile(bundle, fileNameExtendsion, baseFileTypes, compressedFileTypes);
                         bundle = createTransactionBundle();
@@ -324,8 +324,7 @@ public class Csv2Fhir {
      * @param outputFileType
      */
     private File writeBaseOutputFile(Bundle bundle, String fileNameExtension, OutputFileType outputFileType) throws IOException {
-        String fileName = outputFileNameBase + (Strings.isNullOrEmpty(fileNameExtension) ? "" : fileNameExtension)
-                + outputFileType.getFileExtension();
+        String fileName = getOutputFileName(outputFileNameBase, fileNameExtension, outputFileType);
         File outputFile = new File(outputDirectory, fileName);
         LOG.info("writing file " + fileName);
         try (FileWriter fileWriter = new FileWriter(outputFile)) {
@@ -335,6 +334,17 @@ public class Csv2Fhir {
         }
         appendNewLineAtEOF(outputFile);
         return outputFile;
+    }
+
+    static String getOutputFileName(String outputFileNameBase, String fileNameExtension, OutputFileType outputFileType) {
+        String normalizedExtension = Strings.nullToEmpty(fileNameExtension);
+        String fileNameBase = Strings.isNullOrEmpty(normalizedExtension) ? removeTrailingSeparator(outputFileNameBase)
+                : outputFileNameBase + normalizedExtension;
+        return fileNameBase.replaceAll("__", "_") + outputFileType.getFileExtension();
+    }
+
+    private static String removeTrailingSeparator(String fileNameBase) {
+        return fileNameBase.endsWith("_") ? fileNameBase.substring(0, fileNameBase.length() - 1) : fileNameBase;
     }
 
     /**

--- a/src/main/java/de/uni_leipzig/life/csv2fhir/MultiSinglePatientBundlesFileWriter.java
+++ b/src/main/java/de/uni_leipzig/life/csv2fhir/MultiSinglePatientBundlesFileWriter.java
@@ -210,8 +210,7 @@ public class MultiSinglePatientBundlesFileWriter {
      * @return
      */
     private String getFileName(String nameExtension, OutputFileType outputFileType) {
-        String newFileName = outputFileNameBase + nameExtension + outputFileType.getFileExtension();
-        return newFileName.replaceAll("__", "_");
+        return Csv2Fhir.getOutputFileName(outputFileNameBase, nameExtension, outputFileType);
     }
 
     /**

--- a/src/test/java/de/uni_leipzig/life/csv2fhir/Csv2FhirTest.java
+++ b/src/test/java/de/uni_leipzig/life/csv2fhir/Csv2FhirTest.java
@@ -1,0 +1,22 @@
+package de.uni_leipzig.life.csv2fhir;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class Csv2FhirTest {
+
+    @Test
+    public void getOutputFileNameRemovesTrailingSeparatorWithoutExtension() {
+        String fileName = Csv2Fhir.getOutputFileName("FHIR_Testdatengenerator_Vorlage_", "", OutputFileType.JSON);
+
+        assertEquals("FHIR_Testdatengenerator_Vorlage.json", fileName);
+    }
+
+    @Test
+    public void getOutputFileNameKeepsSeparatorWithExtension() {
+        String fileName = Csv2Fhir.getOutputFileName("FHIR_Testdatengenerator_Vorlage_", "PID1", OutputFileType.JSON);
+
+        assertEquals("FHIR_Testdatengenerator_Vorlage_PID1.json", fileName);
+    }
+}


### PR DESCRIPTION
## Summary

- allow Docker Compose runs to pass custom Excel workbook arguments through to excel2fhir.jar
- mount the repository read-only at /app/input while keeping output directories writable
- add Docker defaults for output/temp directories and clearer missing-input errors
- avoid trailing underscores in generated output bundle names and fix single-patient bundle filenames
- document Docker examples for the default template, demo workbook, custom workbooks, validation/NDJSON, and one bundle per patient

## Validation

- mvn test
- docker compose -f docker/docker-compose.yml build excel2fhir
- docker compose -f docker/docker-compose.yml run --rm excel2fhir
- docker compose -f docker/docker-compose.yml run --rm excel2fhir -f /app/input/FHIR_Testdatengenerator_Interpolar_Demo.xlsx -p 1
- missing custom workbook path now returns a concise error instead of a Java stack trace

Closes #25