### PR TITLE
Fix remaining security alerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<hapi.fhir.version>8.8.1</hapi.fhir.version>
 		<slf4j.version>2.0.16</slf4j.version>
-		<log4j.version>2.24.1</log4j.version>
+		<log4j.version>2.25.4</log4j.version>
+		<jackson-core.version>2.21.1</jackson-core.version>
 		<ucum.version>1.0.9</ucum.version>
 	</properties>
 
@@ -34,6 +35,11 @@
 				<groupId>org.fhir</groupId>
 				<artifactId>ucum</artifactId>
 				<version>${ucum.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-core</artifactId>
+				<version>${jackson-core.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/src/main/java/de/uni_leipzig/imise/utils/Excel2Csv.java
+++ b/src/main/java/de/uni_leipzig/imise/utils/Excel2Csv.java
@@ -88,7 +88,8 @@ public class Excel2Csv {
         Stopwatch stopwatch = Stopwatch.createStarted();
         String sourceFileName = FilenameUtils.removeExtension(sourceExcelFile.getName());
         String csvDirBasename = FilenameUtils.removeExtension(targetCsvDir.getPath());
-        try (Workbook workbook = new XSSFWorkbook(new FileInputStream(sourceExcelFile))) {
+        try (FileInputStream sourceInputStream = new FileInputStream(sourceExcelFile);
+                Workbook workbook = new XSSFWorkbook(sourceInputStream)) {
             for (Sheet dataSheet : workbook) {
                 String sheetName = dataSheet.getSheetName();
                 if (sheetNamePatterns != null) {


### PR DESCRIPTION
Fixes the remaining actionable security alerts after PR #30: closes the Excel input stream explicitly and updates vulnerable runtime dependencies used in the shaded Docker image.\n\nValidation: mvn test package