### PR TITLE
Fix stale Javadoc tags

### DIFF
--- a/src/main/java/de/uni_leipzig/imise/Excel2Fhir.java
+++ b/src/main/java/de/uni_leipzig/imise/Excel2Fhir.java
@@ -82,7 +82,7 @@ public class Excel2Fhir {
     }
 
     /**
-     * @param excelDir
+     * @param sourceExcelDir
      * @param sheetNamePatterns if not <code>null</code> then only the sheets with
      *                          a name in this collection will be convertert to
      *                          csv. If <code>null</code> then all sheet will be

--- a/src/main/java/de/uni_leipzig/imise/utils/Alphabetical.java
+++ b/src/main/java/de/uni_leipzig/imise/utils/Alphabetical.java
@@ -97,7 +97,7 @@ public class Alphabetical {
          * über die <code>compare()</code>-Methode des übergebenen Komparators
          * vergleicht.
          *
-         * @param stringComparator
+         * @param realComparator
          */
         public ObjectToStringComparator(final Comparator<Object> realComparator) {
             this.realComparator = realComparator;

--- a/src/main/java/de/uni_leipzig/imise/utils/FileTools.java
+++ b/src/main/java/de/uni_leipzig/imise/utils/FileTools.java
@@ -19,7 +19,7 @@ public class FileTools {
     private static final Logger LOG = LoggerFactory.getLogger(FileTools.class);
 
     /**
-     * @param path
+     * @param file
      * @return
      * @throws IOException
      */

--- a/src/main/java/de/uni_leipzig/imise/utils/StringUtils.java
+++ b/src/main/java/de/uni_leipzig/imise/utils/StringUtils.java
@@ -21,9 +21,9 @@ public class StringUtils {
      * passed string with the given character. If its length is greater than or
      * equal to the length of the second string, it remains unchanged.
      *
-     * @param s
+     * @param stringToFill
      * @param c
-     * @param newMinLenght
+     * @param stringWithMinLength
      * @return
      */
     public static String fillToLenght(final String stringToFill, char c, final String stringWithMinLength) {

--- a/src/main/java/de/uni_leipzig/imise/validate/FHIRValidator.java
+++ b/src/main/java/de/uni_leipzig/imise/validate/FHIRValidator.java
@@ -339,7 +339,6 @@ public class FHIRValidator {
     /**
      * @param resourceAsJson
      * @param strict
-     * @param minLogLevel
      * @return
      */
     public ValidationResultType validate(String resourceAsJson, boolean strict) {

--- a/src/main/java/de/uni_leipzig/life/csv2fhir/BundlePostProcessor.java
+++ b/src/main/java/de/uni_leipzig/life/csv2fhir/BundlePostProcessor.java
@@ -165,7 +165,6 @@ public class BundlePostProcessor {
 
     /**
      * @param encounter
-     * @param bundle
      * @return
      */
     private Encounter getSuperEncounter(Encounter encounter) {

--- a/src/main/java/de/uni_leipzig/life/csv2fhir/ConvertedResources.java
+++ b/src/main/java/de/uni_leipzig/life/csv2fhir/ConvertedResources.java
@@ -39,7 +39,7 @@ public class ConvertedResources<T extends Resource> implements Iterable<T> {
     }
 
     /**
-     * @param key
+     * @param id
      * @return
      * @see java.util.Map#get(java.lang.Object)
      */

--- a/src/main/java/de/uni_leipzig/life/csv2fhir/ConverterResult.java
+++ b/src/main/java/de/uni_leipzig/life/csv2fhir/ConverterResult.java
@@ -267,7 +267,7 @@ public class ConverterResult {
 
         /**
          * @param resourceType
-         * @param value2Add
+         * @param ids
          */
         private void add(Class<? extends Resource> resourceType, Collection<String> ids) {
             Integer oldCount = resourceCounts.getOrDefault(resourceType, 0);

--- a/src/main/java/de/uni_leipzig/life/csv2fhir/converter/ConsentConverter.java
+++ b/src/main/java/de/uni_leipzig/life/csv2fhir/converter/ConsentConverter.java
@@ -134,7 +134,6 @@ public class ConsentConverter extends Converter {
     }
 
     /**
-     * @param consentDate
      * @return
      * @throws Exception
      */
@@ -205,7 +204,6 @@ public class ConsentConverter extends Converter {
     /**
      * @param date
      * @param years
-     * @param minusOneDay
      */
     private static void addYears(DateTimeType date, int years) {
         date.add(Calendar.YEAR, years);

--- a/src/main/java/de/uni_leipzig/life/csv2fhir/converter/ObservationLaboratoryConverter.java
+++ b/src/main/java/de/uni_leipzig/life/csv2fhir/converter/ObservationLaboratoryConverter.java
@@ -146,7 +146,6 @@ public class ObservationLaboratoryConverter extends Converter {
     }
 
     /**
-     * @param converter
      * @param valueColumnIdentifier
      * @param unitColumnIdentifier
      * @return

--- a/src/main/java/de/uni_leipzig/life/csv2fhir/ucum/UcumCodesExtractor.java
+++ b/src/main/java/de/uni_leipzig/life/csv2fhir/ucum/UcumCodesExtractor.java
@@ -7,7 +7,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -171,7 +170,6 @@ public class UcumCodesExtractor {
     /**
      * @param ucumCodeToDisplayMapper
      * @throws IOException
-     * @throws URISyntaxException
      */
     private static void extractSynonymsMap(BothDirectionResourceMapper ucumCodeToDisplayMapper) throws IOException {
         File targetMapFile = new File(RESOURCE_SUB_DIR,

--- a/src/main/java/de/uni_leipzig/life/csv2fhir/utils/BothDirectionResourceMapper.java
+++ b/src/main/java/de/uni_leipzig/life/csv2fhir/utils/BothDirectionResourceMapper.java
@@ -90,7 +90,7 @@ public class BothDirectionResourceMapper implements Map<String, String> {
     }
 
     /**
-     * @param resourceFileName
+     * @param resourceFileNames
      */
     public BothDirectionResourceMapper(String... resourceFileNames) {
         for (String resourceFileName : resourceFileNames) {

--- a/src/main/java/de/uni_leipzig/life/csv2fhir/utils/JSONFunctions.java
+++ b/src/main/java/de/uni_leipzig/life/csv2fhir/utils/JSONFunctions.java
@@ -157,8 +157,6 @@ public class JSONFunctions {
     /**
      * @param jsonArray
      * @param pathInJSONArrayEntryToString
-     * @param matchCondition
-     * @param conditionValues
      * @return
      */
     public static List<JSONObject> getEntriesWithValue(final JSONArray jsonArray,
@@ -184,10 +182,8 @@ public class JSONFunctions {
 
     /**
      * @param jsonArray
-     * @param pathInJSONArrayEntryToString
-     * @param matchCondition
+     * @param pathInJSONArrayEntryToSubEntry
      * @param returnOnlyFirstValue
-     * @param conditionValues
      * @return
      */
     private static List<JSONObject> getEntriesWithValue(final JSONArray jsonArray,

--- a/src/test/java/de/uni_leipzig/life/csv2fhir/converter/ConditionConverterTest.java
+++ b/src/test/java/de/uni_leipzig/life/csv2fhir/converter/ConditionConverterTest.java
@@ -58,7 +58,7 @@ public class ConditionConverterTest {
 
     /**
      * @param codeInput
-     * @param resultCodes
+     * @param expectedResultCodes
      */
     private static void testConvert(String codeInput, String... expectedResultCodes) throws Exception {
         ConverterResult result = new ConverterResult(new ConverterOptions(""));


### PR DESCRIPTION
Cleans up the remaining CodeQL documentation notes on develop by aligning stale Javadoc @param tags with the actual method signatures and removing an impossible @throws tag.\n\nValidation: mvn test